### PR TITLE
Add TypeScript simulation of Zoho CRM lead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Zoho CRM Lead Simulation
 
-Este repositorio contiene un ejemplo sencillo para simular un registro de **Lead** utilizando campos habituales de Zoho CRM. Se incluyen dos archivos TypeScript:
+Este repositorio contiene un ejemplo sencillo para simular un registro de **Lead** utilizando campos habituales de Zoho CRM.
+
+## Archivos
 
 - `leadInterface.ts` define las interfaces `Lead` y `ProgramInfo` con comentarios en español que describen la función de cada campo.
-- `simulateLead.ts` crea una instancia de `Lead` y de `ProgramInfo` para demostrar cómo se pueden utilizar.
+- `simulateLead.ts` crea una instancia de `Lead` y `ProgramInfo` para demostrar cómo se podrían utilizar los tipos.
+- `leadForm.html` es una interfaz HTML sencilla que permite introducir todos los campos de un Lead y ver el resultado en formato JSON.
 
 Los archivos no requieren conexión con Zoho CRM; sirven únicamente como plantilla o punto de partida para futuras integraciones.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# zoho
+# Zoho CRM Lead Simulation
+
+Este repositorio contiene un ejemplo sencillo para simular un registro de **Lead** utilizando campos habituales de Zoho CRM. Se incluyen dos archivos TypeScript:
+
+- `leadInterface.ts` define las interfaces `Lead` y `ProgramInfo` con comentarios en español que describen la función de cada campo.
+- `simulateLead.ts` crea una instancia de `Lead` y de `ProgramInfo` para demostrar cómo se pueden utilizar.
+
+Los archivos no requieren conexión con Zoho CRM; sirven únicamente como plantilla o punto de partida para futuras integraciones.

--- a/leadForm.html
+++ b/leadForm.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Formulario de Lead</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    label { display: block; margin-top: 10px; }
+    input, textarea, select { width: 300px; }
+  </style>
+</head>
+<body>
+  <h1>Simulación de Lead Zoho CRM</h1>
+  <form id="leadForm">
+    <fieldset>
+      <legend>Encabezado</legend>
+      <label>
+        Nombre del lead
+        <input type="text" name="nombreLead" required>
+      </label>
+      <label>
+        Gestión Manual
+        <input type="checkbox" name="gestionManual">
+      </label>
+    </fieldset>
+
+    <fieldset>
+      <legend>Datos de usuario</legend>
+      <label>
+        Contacto (ID)
+        <input type="text" name="contactoId">
+      </label>
+      <label>
+        Nombre
+        <input type="text" name="nombre" required>
+      </label>
+      <label>
+        Apellidos
+        <input type="text" name="apellidos">
+      </label>
+      <label>
+        Dirección
+        <textarea name="direccion"></textarea>
+      </label>
+      <label>
+        Correo electrónico
+        <input type="email" name="correoElectronico" required>
+      </label>
+      <label>
+        Móvil
+        <input type="tel" name="movil">
+      </label>
+      <label>
+        Teléfono
+        <input type="tel" name="telefono">
+      </label>
+    </fieldset>
+
+    <fieldset>
+      <legend>Comercial</legend>
+      <label>
+        Comercial (ID)
+        <input type="text" name="comercialId" required>
+      </label>
+      <label>
+        Equipo de ventas
+        <input type="text" name="equipoVentasId">
+      </label>
+      <label>
+        Unidad de operación
+        <input type="text" name="unidadOperacion" value="Euroinnova S.L.">
+      </label>
+      <label>
+        Estado
+        <select name="estado">
+          <option value="Nuevo">Nuevo</option>
+          <option value="Contactado">Contactado</option>
+          <option value="Calificado">Calificado</option>
+          <option value="Descalificado">Descalificado</option>
+        </select>
+      </label>
+      <label>
+        Calificación (0-100)
+        <input type="number" name="calificacion" min="0" max="100" value="0">
+      </label>
+      <label>
+        Prioridad (1-5)
+        <input type="number" name="prioridad" min="1" max="5" value="3">
+      </label>
+      <label>
+        Etiquetas (separar por comas)
+        <input type="text" name="etiquetas">
+      </label>
+    </fieldset>
+
+    <fieldset>
+      <legend>Programa</legend>
+      <label>
+        Programa (ID)
+        <input type="text" name="programaId">
+      </label>
+      <label>
+        Titulación
+        <input type="text" name="titulo" readonly>
+      </label>
+      <label>
+        Especialidad
+        <input type="text" name="especialidad" readonly>
+      </label>
+      <label>
+        Modalidad
+        <input type="text" name="modalidad" readonly>
+      </label>
+      <label>
+        Convocatoria Cerem
+        <input type="text" name="convocatoriaCerem" readonly>
+      </label>
+    </fieldset>
+
+    <fieldset>
+      <legend>Marketing</legend>
+      <label>
+        UTM Campaña
+        <input type="text" name="utmCampana">
+      </label>
+      <label>
+        UTM Medio
+        <input type="text" name="utmMedio">
+      </label>
+      <label>
+        UTM Fuente
+        <input type="text" name="utmFuente">
+      </label>
+      <label>
+        gclid
+        <input type="text" name="gclid">
+      </label>
+      <label>
+        fbclid
+        <input type="text" name="fbclid">
+      </label>
+    </fieldset>
+
+    <fieldset>
+      <legend>Notas internas</legend>
+      <textarea name="notas" rows="4" cols="50"></textarea>
+    </fieldset>
+
+    <button type="submit">Guardar</button>
+  </form>
+
+  <pre id="output"></pre>
+
+  <script>
+    const form = document.getElementById('leadForm');
+    const output = document.getElementById('output');
+    form.addEventListener('submit', function(event) {
+      event.preventDefault();
+      const data = Object.fromEntries(new FormData(form).entries());
+      data.gestionManual = form.gestionManual.checked;
+      output.textContent = JSON.stringify(data, null, 2);
+    });
+  </script>
+</body>
+</html>

--- a/leadInterface.ts
+++ b/leadInterface.ts
@@ -1,0 +1,39 @@
+export interface Lead {
+  // Encabezado
+  nombreLead: string; // Nombre del lead: Programa + modalidad + marca
+  gestionManual: boolean; // Gestión Manual: si activo no entra en reglas automáticas
+  // Widget Llamadas se maneja externamente
+
+  // Datos de usuario
+  contactoId?: string; // Lookup a Contacto (opcional)
+  nombre: string; // Nombre de pila
+  apellidos: string; // Apellidos
+  direccion: string; // País + ciudad
+  correoElectronico: string; // Email
+  movil: string; // Móvil
+  telefono: string; // Teléfono alternativo
+
+  // Comercial
+  comercialId: string; // Asesor asignado
+  equipoVentasId?: string; // Equipo de ventas
+  unidadOperacion: string; // Unidad de operación
+  estado: string; // Nuevo, Contactado, etc.
+  calificacion: number; // 0-100
+  prioridad: number; // 0-5
+  etiquetas: string[]; // Etiquetas o Tags
+
+  // Sub-tabs simplificados
+  programaId?: string; // Lookup a Programa
+  utmCampana?: string;
+  utmMedio?: string;
+  utmFuente?: string;
+  gclid?: string;
+  fbclid?: string;
+}
+
+export interface ProgramInfo {
+  titulo: string; // Titulación
+  especialidad?: string;
+  modalidad: 'Online' | 'Presencial' | 'Hibrido';
+  convocatoriaCerem?: string;
+}

--- a/simulateLead.ts
+++ b/simulateLead.ts
@@ -1,0 +1,37 @@
+import { Lead, ProgramInfo } from './leadInterface';
+
+// Ejemplo de lead con información básica y programa relacionado
+const lead: Lead = {
+  nombreLead: 'Programa XYZ - Online - Marca A',
+  gestionManual: false,
+  contactoId: 'contacto123',
+  nombre: 'Juan',
+  apellidos: 'Pérez',
+  direccion: 'España, Madrid',
+  correoElectronico: 'juan.perez@example.com',
+  movil: '+34123456789',
+  telefono: '+34987654321',
+  comercialId: 'user1',
+  equipoVentasId: 'teamA',
+  unidadOperacion: 'Euroinnova S.L.',
+  estado: 'Nuevo',
+  calificacion: 80,
+  prioridad: 4,
+  etiquetas: ['campaña verano', 'evento feria'],
+  programaId: 'prog1',
+  utmCampana: 'verano2024',
+  utmMedio: 'email',
+  utmFuente: 'newsletter',
+  gclid: 'abcd1234',
+  fbclid: 'efgh5678'
+};
+
+const programa: ProgramInfo = {
+  titulo: 'Máster en Gestión',
+  especialidad: 'Dirección',
+  modalidad: 'Online',
+  convocatoriaCerem: '2024'
+};
+
+console.log('Lead:', lead);
+console.log('Programa:', programa);


### PR DESCRIPTION
## Summary
- define `Lead` and `ProgramInfo` interfaces describing common Zoho CRM fields
- provide a `simulateLead.ts` example with sample data
- update README with basic instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68409ceba154832087a74978ca99cb0c